### PR TITLE
Upgrade Swoole version to v6.1.1

### DIFF
--- a/.github/workflows/build-swoole.yml
+++ b/.github/workflows/build-swoole.yml
@@ -3,7 +3,7 @@ name: Build Swoole
 on: [ push ]
 env:
   ENGINE: 'swoole'
-  SW_VERSION: 'v6.1.0'
+  SW_VERSION: 'v6.1.1'
   COMPOSER_VERSION: '2.8.12'
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_ACCESSTOKEN }}


### PR DESCRIPTION
## Summary

This PR upgrades the Swoole version from v6.1.0 to v6.1.1 in the GitHub Actions workflow.

## Changes

- Updated `SW_VERSION` from `v6.1.0` to `v6.1.1` in `.github/workflows/build-swoole.yml`
- Maintained Composer version at `2.8.12`

## Test plan

- [ ] Verify that the GitHub Actions workflow runs successfully with the new Swoole version
- [ ] Ensure Docker images build correctly with Swoole v6.1.1
- [ ] Test that existing functionality remains compatible